### PR TITLE
Load DINOv2 model weights from official fb torchhub account

### DIFF
--- a/basicsr/archs/vqgan3D_arch.py
+++ b/basicsr/archs/vqgan3D_arch.py
@@ -601,10 +601,8 @@ class VQGANDiscriminator3D(nn.Module):
             },
         }
         self.backbone = load(
-            "/nas2/yutong/dinov2-main",
-            self.backbones[backbone]["name"],
-            trust_repo=True,
-            source="local",
+            "facebookresearch/dinov2",
+            self.backbones[backbone]["name"]
         )
         for param in self.backbone.parameters():
             param.requires_grad = False


### PR DESCRIPTION
Hi, thank you for publishing your great work!

I noticed while setting up the project that DINOv2 weights are loaded from some inaccessible NAS location.
I assume you're just using the official model weights from FB so loading them directly from their TorchHub should be the correct fix?